### PR TITLE
Refactor `rgba/grayImage` to `toEasyImage`

### DIFF
--- a/src-awt/org/koherent/image/ImageAWT.kt
+++ b/src-awt/org/koherent/image/ImageAWT.kt
@@ -4,17 +4,17 @@ import java.awt.image.BufferedImage
 
 import java.awt.image.DataBufferByte
 
-fun rgbaImage(from: BufferedImage): Image<RGBA<Byte>> {
-    when (from.type) {
+fun BufferedImage.toEasyImage(type: ParameterType.RGBAByte = ParameterType.RGBAByte): Image<RGBA<Byte>> {
+    when (this.type) {
         BufferedImage.TYPE_4BYTE_ABGR -> {}
         else -> {
-            val converted = BufferedImage(from.width, from.height, BufferedImage.TYPE_4BYTE_ABGR)
-            converted.graphics.drawImage(from, 0, 0, null)
-            return rgbaImage(converted)
+            val converted = BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR)
+            converted.graphics.drawImage(this, 0, 0, null)
+            return converted.toEasyImage(ParameterType.RGBAByte)
         }
     }
 
-    val bytes = (from.raster.dataBuffer as DataBufferByte).data
+    val bytes = (raster.dataBuffer as DataBufferByte).data
     val pixels: MutableList<RGBA<Byte>> = mutableListOf()
     bytes.forEachIndexed { i, value ->
         val channel = i % 4
@@ -31,11 +31,11 @@ fun rgbaImage(from: BufferedImage): Image<RGBA<Byte>> {
         }
     }
 
-    return Image(from.width, from.height, pixels.toTypedArray())
+    return Image(width, height, pixels.toTypedArray())
 }
 
-fun grayImage(from: BufferedImage): Image<Byte> {
-    return rgbaImage(from).map { ((it.grayInt * it.alphaInt) / 255).toByte() }
+fun BufferedImage.toEasyImage(type: ParameterType.Byte = ParameterType.Byte): Image<Byte> {
+    return toEasyImage(ParameterType.RGBAByte).map { ((it.grayInt * it.alphaInt) / 255).toByte() }
 }
 
 fun Image<RGBA<Byte>>.toBufferedImage(type: ParameterType.RGBAByte = ParameterType.RGBAByte): BufferedImage {

--- a/src-javafx/org/koherent/image/ImageJavaFX.kt
+++ b/src-javafx/org/koherent/image/ImageJavaFX.kt
@@ -3,11 +3,11 @@ package org.koherent.image
 import javafx.embed.swing.SwingFXUtils
 
 fun javafx.scene.image.Image.toEasyImage(type: ParameterType.RGBAByte = ParameterType.RGBAByte): Image<RGBA<Byte>> {
-    return rgbaImage(SwingFXUtils.fromFXImage(this, null))
+    return SwingFXUtils.fromFXImage(this, null).toEasyImage(type)
 }
 
 fun javafx.scene.image.Image.toEasyImage(type: ParameterType.Byte = ParameterType.Byte): Image<Byte> {
-    return grayImage(SwingFXUtils.fromFXImage(this, null))
+    return SwingFXUtils.fromFXImage(this, null).toEasyImage(type)
 }
 
 fun Image<RGBA<Byte>>.toFXImage(type: ParameterType.RGBAByte = ParameterType.RGBAByte): javafx.scene.image.Image {

--- a/test-awt/org/koherent/image/ImageAWTTest.kt
+++ b/test-awt/org/koherent/image/ImageAWTTest.kt
@@ -9,7 +9,7 @@ class ImageAWTTest {
     @Test
     fun testRgbaImage() {
         run {
-            val image = rgbaImage(ImageIO.read(File("res/test-2x1.png")))
+            val image = ImageIO.read(File("res/test-2x1.png")).toEasyImage(ParameterType.RGBAByte)
             assertEquals(image.width, 2)
             assertEquals(image.height, 1)
 
@@ -25,7 +25,7 @@ class ImageAWTTest {
         }
 
         run {
-            val image = rgbaImage(ImageIO.read(File("res/test-2x2.png")))
+            val image = ImageIO.read(File("res/test-2x2.png")).toEasyImage(ParameterType.RGBAByte)
             assertEquals(image.width, 2)
             assertEquals(image.height, 2)
 
@@ -54,7 +54,7 @@ class ImageAWTTest {
     @Test
     fun testGrayImage() {
         run {
-            val image = grayImage(ImageIO.read(File("res/test-2x1.png")))
+            val image = ImageIO.read(File("res/test-2x1.png")).toEasyImage(ParameterType.Byte)
             assertEquals(image.width, 2)
             assertEquals(image.height, 1)
 
@@ -63,7 +63,7 @@ class ImageAWTTest {
         }
 
         run {
-            val image = grayImage(ImageIO.read(File("res/test-2x2.png")))
+            val image = ImageIO.read(File("res/test-2x2.png")).toEasyImage(ParameterType.Byte)
             assertEquals(image.width, 2)
             assertEquals(image.height, 2)
 


### PR DESCRIPTION
Because `toEasyImage` is more natural in Kotlin.